### PR TITLE
Delete unused parameter

### DIFF
--- a/src/Patreon/OAuth.php
+++ b/src/Patreon/OAuth.php
@@ -20,7 +20,7 @@ class OAuth {
     ));
   }
 
-  public function refresh_token($refresh_token, $redirect_uri) {
+  public function refresh_token($refresh_token) {
     return $this->__update_token(array(
         "grant_type" => "refresh_token",
         "refresh_token" => $refresh_token,

--- a/src/Patreon/OAuth.php
+++ b/src/Patreon/OAuth.php
@@ -20,7 +20,7 @@ class OAuth {
     ));
   }
 
-  public function refresh_token($refresh_token) {
+  public function refresh_token($refresh_token, $redirect_uri = null) {
     return $this->__update_token(array(
         "grant_type" => "refresh_token",
         "refresh_token" => $refresh_token,


### PR DESCRIPTION
redirect_url is not used by refresh_token but it is required as a parameter.