### PR TITLE
Remove unused argument to refresh_token

### DIFF
--- a/src/Patreon/OAuth.php
+++ b/src/Patreon/OAuth.php
@@ -20,7 +20,7 @@ class OAuth {
     ));
   }
 
-  public function refresh_token($refresh_token, $redirect_uri) {
+  public function refresh_token($refresh_token) {
     return $this->__update_token(array(
         "grant_type" => "refresh_token",
         "refresh_token" => $refresh_token,


### PR DESCRIPTION
The `$redirect_uri` was unused.
I did not check the spec if a token refresh can also have a `redirect_uri`.

If it has this optional parameter it should probably be re-added but used properly.