### PR TITLE
Add examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,15 @@ This will provide you with a `client_id` and a `client_secret`.
 
 Step 2. Use this plugin
 ---
-e.g., in a PHP page
+Let's say you wanted to make a "Log In with Patreon" button.
+You've read through [the directions](https://www.patreon.com/platform/documentation/oauth),
+and are trying to implement "Step 2: Handling the OAuth Redirect" with your server.
+The user will be arriving at one of your pages *after* you have sent them to [the authorize page](www.patreon.com/oauth2/authorize) for step 1,
+so in their query parameters landing on this page,
+they will have a parameter `'code'`.
+
+_(If you are doing something other than the "Log In with Patreon" flow, please see [the examples folder](examples) for more examples)_
+
 ```php
 <?php
 
@@ -28,15 +36,18 @@ $creator_id = null;     // Replace with your data
 $oauth_client = new Patreon\OAuth($client_id, $client_secret);
 
 // Replace http://localhost:5000/oauth/redirect with your own uri
-$tokens = $oauth_client->get_tokens($_GET['code'], "http://localhost:5000/oauth/redirect");
+$redirect_uri = "http://localhost:5000/oauth/redirect";
+// Make sure that you're using this snippet as Step 2 of the OAuth flow: https://www.patreon.com/platform/documentation/oauth
+// so that you have the 'code' query parameter.
+$tokens = $oauth_client->get_tokens($_GET['code'], $redirect_uri);
 $access_token = $tokens['access_token'];
+$refresh_token = $tokens['refresh_token'];
 
 $api_client = new Patreon\API($access_token);
-$user_response = $api_client->fetch_user();
-$user = $user_response['data'];
-$included = $user_response['included'];
+$patron_response = $api_client->fetch_user();
+$patron = $patron_response['data'];
+$included = $patron_response['included'];
 $pledge = null;
-$campaign = null;
 if ($included != null) {
   foreach ($included as $obj) {
     if ($obj["type"] == "pledge" && $obj["relationships"]["creator"]["data"]["id"] == $creator_id) {
@@ -44,15 +55,18 @@ if ($included != null) {
       break;
     }
   }
-  foreach ($included as $obj) {
-    if ($obj["type"] == "campaign" && $obj["relationships"]["creator"]["data"]["id"] == $creator_id) {
-      $campaign = $obj;
-      break;
-    }
-  }
 }
 
-// use $user, $pledge, and $campaign as desired
+/*
+ $patron will have the authenticated user's user data, and
+ $pledge will have their patronage data.
+ Typically, you will save the relevant pieces of this data to your database,
+ linked with their user account on your site,
+ so your site can customize its experience based on their Patreon data.
+ You will also want to save their $access_token and $refresh_token to your database,
+ linked to their user account on your site,
+ so that you can refresh their Patreon data on your own schedule.
+ */
 
 ?>
 ```

--- a/examples/patron-list.php
+++ b/examples/patron-list.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ If you're ever validating that a user on your site is a patron,
+ you should *not* use this code.
+ Instead, please use the proper OAuth flow,
+ as detailed [in the documentation](https://www.patreon.com/platform/documentation/oauth)
+ and in the snippet [in the README](https://www.github.com/Patreon/patreon-php/blob/master/README.md)
+
+ If you want to just get a list of your patrons for non-authentication purposes,
+ this snippet is a good example of how to do so.
+ */
+
+require_once('vendor/patreon/patreon/src/patreon.php');
+
+use Patreon\API;
+use Patreon\OAuth;
+
+// Get your current "Creator's Access Token" from https://www.patreon.com/platform/documentation/clients
+$access_token = null;
+// Get your "Creator's Refesh Token" from https://www.patreon.com/platform/documentation/clients
+$refresh_token = null;
+$api_client = new Patreon\API($access_token);
+
+// Get your campaign data
+$campaign_response = $api_client->fetch_campaign();
+
+// If the token doesn't work, get a newer one
+if ($campaign_response['errors']) {
+    // Make an OAuth client
+    // Get your Client ID and Secret from https://www.patreon.com/platform/documentation/clients
+    $client_id = null;
+    $client_secret = null;
+    $oauth_client = new Patreon\OAuth($client_id, $client_secret);
+    // Get a fresher access token
+    $tokens = $oauth_client->refresh_token($refresh_token, null);
+    if ($tokens['access_token']) {
+        $access_token = $tokens['access_token'];
+        echo "Got a new access_token! Please overwrite the old one in this script with: " . $access_token . " and try again.";
+    } else {
+        echo "Can't recover from access failure\n";
+        print_r($tokens);
+    }
+}
+
+// get page after page of pledge data
+$campaign_id = $campaign_response['data'][0]['id'];
+$cursor = null;
+while (true) {
+    $pledges_response = $api_client->fetch_page_of_pledges($campaign_id, 25, $cursor);
+    // get all the users in an easy-to-lookup way
+    $user_data = [];
+    foreach ($pledges_response['included'] as $included_data) {
+        if ($included_data['type'] == 'user') {
+            $user_data[$included_data['id']] = $included_data;
+        }
+    }
+    // loop over the pledges to get e.g. their amount and user name
+    foreach ($pledges_response['data'] as $pledge_data) {
+        $pledge_amount = $pledge_data['attributes']['amount_cents'];
+        $patron_id = $pledge_data['relationships']['patron']['data']['id'];
+        $patron_full_name = $user_data[$patron_id]['attributes']['full_name'];
+        echo $patron_full_name . " is pledging " . $pledge_amount . " cents.\n";
+    }
+    // get the link to the next page of pledges
+    $next_link = $pledges_response['links']['next'];
+    if (!$next_link) {
+        // if there's no next page, we're done!
+        break;
+    }
+    // otherwise, parse out the cursor param
+    $next_query_params = explode("?", $next_link)[1];
+    parse_str($next_query_params, $parsed_next_query_params);
+    $cursor = $parsed_next_query_params['page']['cursor'];
+}
+
+echo "Done!";
+
+?>


### PR DESCRIPTION
We were getting quite a few people who didn't understand the point of the prominent snippet in the README, and just wanted to use this library to get a list of their patrons for non-authentication purposes. This PR clarifies the README language as to the snippet's purpose, and adds a new `examples` folder with an example of how to use this library to get a list of patrons.