### PR TITLE
Remove redundant Patreon\ statements from examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ use Patreon\OAuth;
 $client_id = null;      // Replace with your data
 $client_secret = null;  // Replace with your data
 
-$oauth_client = new Patreon\OAuth($client_id, $client_secret);
+$oauth_client = new OAuth($client_id, $client_secret);
 
 // Replace http://localhost:5000/oauth/redirect with your own uri
 $redirect_uri = "http://localhost:5000/oauth/redirect";
@@ -49,7 +49,7 @@ $tokens = $oauth_client->get_tokens($_GET['code'], $redirect_uri);
 $access_token = $tokens['access_token'];
 $refresh_token = $tokens['refresh_token'];
 
-$api_client = new Patreon\API($access_token);
+$api_client = new API($access_token);
 $patron_response = $api_client->fetch_user();
 /*
  * The $patron_response is now a [art4/json-api-client/Document](https://github.com/Art4/json-api-client/blob/master/docs/objects-document.md)

--- a/examples/patron-list.php
+++ b/examples/patron-list.php
@@ -20,7 +20,7 @@ use Patreon\OAuth;
 $access_token = null;
 // Get your "Creator's Refesh Token" from https://www.patreon.com/platform/documentation/clients
 $refresh_token = null;
-$api_client = new Patreon\API($access_token);
+$api_client = new API($access_token);
 
 // Get your campaign data
 $campaign_response = $api_client->fetch_campaign();
@@ -35,7 +35,7 @@ if ($campaign_response->has('errors')) {
     // Get your Client ID and Secret from https://www.patreon.com/platform/documentation/clients
     $client_id = null;
     $client_secret = null;
-    $oauth_client = new Patreon\OAuth($client_id, $client_secret);
+    $oauth_client = new OAuth($client_id, $client_secret);
     // Get a fresher access token
     $tokens = $oauth_client->refresh_token($refresh_token, null);
     if ($tokens['access_token']) {


### PR DESCRIPTION
The `use` statements at the top of the file already "include" the classes into the current scope, no need to use the fully qualified names with them.