### PR TITLE
php 7.2 compatibility

### DIFF
--- a/src/API.php
+++ b/src/API.php
@@ -158,7 +158,7 @@ class API {
 		
 		// If the cache array is larger than 50, snip the first item. This may be increased in future
 		
-		if ( count( self::$request_cache ) > 50  ) {
+		if ( !empty(self::$request_cache) && (count( self::$request_cache ) > 50)  ) {
 			array_shift( self::$request_cache );
 		}
 		


### PR DESCRIPTION
!empty check for error "count(): Parameter must be an array or an object that implements Countable" when using php 7.2 or higher

self::$request_cache is null by default