### PR TITLE
Soatok's great refactoring pull request:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+/.idea/
 /vendor/
+composer.lock
 composer.phar

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # patreon-php
 
-Interact with the Patreon API via OAuth.
+Interact with the Patreon API via OAuth. Requires PHP 7.
 
 ## Important notice about updating to 1.0.0 from earlier versions
 

--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,19 @@
         }
     ],
     "minimum-stability": "dev",
+    "autoload-dev": {
+        "Patreon\\Tests\\": "tests/"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^6|^7|^8",
+        "vimeo/psalm": "^2|^3"
+    },
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=7.0.0",
+        "paragonie/hidden-string": "^1",
+        "paragonie/sodium_compat": "^1",
+        "ext-curl": "*",
+        "ext-json": "*"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,7 @@
+<phpunit bootstrap="vendor/autoload.php">
+    <testsuites>
+        <testsuite name="Patreon Tests">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<psalm
+    totallyTyped="false"
+    resolveFromConfigFile="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+>
+    <projectFiles>
+        <directory name="src" />
+        <ignoreFiles>
+            <directory name="vendor" />
+        </ignoreFiles>
+    </projectFiles>
+
+    <issueHandlers>
+        <LessSpecificReturnType errorLevel="info" />
+
+        <!-- level 3 issues - slightly lazy code writing, but provably low false-negatives -->
+
+        <DeprecatedMethod errorLevel="info" />
+        <DeprecatedProperty errorLevel="info" />
+        <DeprecatedClass errorLevel="info" />
+        <DeprecatedConstant errorLevel="info" />
+        <DeprecatedFunction errorLevel="info" />
+        <DeprecatedInterface errorLevel="info" />
+        <DeprecatedTrait errorLevel="info" />
+
+        <InternalMethod errorLevel="info" />
+        <InternalProperty errorLevel="info" />
+        <InternalClass errorLevel="info" />
+
+        <MissingClosureReturnType errorLevel="info" />
+        <MissingReturnType errorLevel="info" />
+        <MissingPropertyType errorLevel="info" />
+        <InvalidDocblock errorLevel="info" />
+        <MisplacedRequiredParam errorLevel="info" />
+
+        <PropertyNotSetInConstructor errorLevel="info" />
+        <MissingConstructor errorLevel="info" />
+        <MissingClosureParamType errorLevel="info" />
+        <MissingParamType errorLevel="info" />
+
+        <RedundantCondition errorLevel="info" />
+
+        <DocblockTypeContradiction errorLevel="info" />
+        <RedundantConditionGivenDocblockType errorLevel="info" />
+
+        <UnresolvableInclude errorLevel="info" />
+
+        <RawObjectIteration errorLevel="info" />
+
+        <InvalidStringClass errorLevel="info" />
+    </issueHandlers>
+</psalm>

--- a/src/API.php
+++ b/src/API.php
@@ -1,140 +1,291 @@
 <?php
 namespace Patreon;
 
-class API {
-	
-	// Holds the access token
+use ParagonIE\HiddenString\HiddenString;
+use Patreon\Exceptions\APIException;
+use Patreon\Exceptions\CurlException;
+
+/**
+ * Class API
+ * @package Patreon
+ */
+class API
+{
+    /**
+     * Holds the access token
+     *
+     * @var HiddenString $access_token
+     */
 	private $access_token;
-	
-	// Holds the api endpoint used
+
+    /**
+     * Holds the api endpoint used
+     *
+     * @var string $api_endpoint
+     */
 	public $api_endpoint;
-	
-	// The cache for request results - an array that matches md5 of the unique API request to the returned result
+
+    /**
+     * The cache for request results - an array that matches hash of the unique
+     * API request to the returned result
+     *
+     * @var array $request_cache
+     */
 	public static $request_cache;
 	
 	// Sets the reqeuest method for cURL
+    /** @var string $api_request_method */
 	public $api_request_method = 'GET';
 	
 	// Holds POST for cURL for requests other than GET
+    /** @var string|array|bool $curl_postfields */
 	public $curl_postfields = false;
 	
 	// Sets the format the return from the API is parsed and returned - array (assoc), object, or raw JSON
+    /** @var string $api_return_format */
 	public $api_return_format;
-	
-	
-	public function __construct($access_token) {
-		
+
+    /**
+     * API constructor.
+     * @param string|HiddenString $access_token
+     */
+	public function __construct($access_token)
+    {
+        if (!($access_token instanceof HiddenString)) {
+            $access_token = new HiddenString($access_token);
+        }
 		// Set the access token
 		$this->access_token = $access_token;
-		
+
 		// Set API endpoint to use. Its currently V2
 		$this->api_endpoint = "https://www.patreon.com/api/oauth2/v2/";
 		
 		// Set default return format - this can be changed by the app using the lib by setting it 
 		// after initialization of this class
 		$this->api_return_format = 'array';
-		
 	}
 
-	public function fetch_user() {
-		// Fetches details of the current token user. 
-		return $this->get_data('identity?include=memberships&fields'.urlencode('[user]').'=email,first_name,full_name,image_url,last_name,thumb_url,url,vanity,is_email_verified&fields'.urlencode('[member]').'=currently_entitled_amount_cents,lifetime_support_cents,last_charge_status,patron_status,last_charge_date,pledge_relationship_start');
+    /**
+     * Fetches details of the current token user.
+     *
+     * @return array|object|string
+     * @throws APIException
+     * @throws CurlException
+     * @throws \SodiumException
+     */
+	public function fetch_user()
+    {
+        return $this->get_data('identity', [
+            'include' => 'memberships',
+            'fields' => [
+                'user' => implode(',', [
+                    'email', 'first_name', 'full_name', 'image_url', 'last_name',
+                    'thumb_url', 'url', 'vanity', 'is_email_verified'
+                ]),
+                'member' => implode(',', [
+                    'currently_entitled_amount_cents',
+                    'lifetime_support_cents',
+                    'last_charge_status',
+                    'patron_status',
+                    'last_charge_date',
+                    'pledge_relationship_start'
+                ])
+            ]
+        ]);
 	}
 
-	public function fetch_campaigns() {
-		// Fetches the list of campaigns of the current token user. Requires the current user to be creator of the campaign or requires a creator access token
+    /**
+     * Fetches the list of campaigns of the current token user.
+     *
+     * Requires the current user to be creator of the campaign
+     * or requires a creator access token.
+     *
+     * @return array|object|string
+     * @throws APIException
+     * @throws CurlException
+     * @throws \SodiumException
+     */
+	public function fetch_campaigns()
+    {
 		return $this->get_data("campaigns");
 	}
-	
-	public function fetch_campaign_details($campaign_id) {
-		// Fetches details about a campaign - the membership tiers, benefits, creator and goals.  Requires the current user to be creator of the campaign or requires a creator access token
-		return $this->get_data("campaigns/{$campaign_id}?include=benefits,creator,goals,tiers");
-	}
-	
-	public function fetch_member_details($member_id) {
-		// Fetches details about a member from a campaign. Member id can be acquired from fetch_page_of_members_from_campaign
-		// currently_entitled_tiers is the best way to get info on which membership tiers the user is entitled to.  Requires the current user to be creator of the campaign or requires a creator access token.
-		return $this->get_data("members/{$member_id}?include=address,campaign,user,currently_entitled_tiers");
+
+    /**
+     * Fetches details about a campaign - the membership tiers, benefits, creator and goals.
+     *
+     * Requires the current user to be creator of the campaign or requires a creator access
+     * token.
+     *
+     * @param string|int $campaign_id
+     * @return array|object|string
+     * @throws APIException
+     * @throws CurlException
+     * @throws \SodiumException
+     */
+	public function fetch_campaign_details($campaign_id)
+    {
+        return $this->get_data('campaigns/' . $campaign_id, [
+                'include' => implode(',', [
+                    'benefits',
+                    'creator',
+                    'goals',
+                    'tiers'
+                ])
+            ]
+        );
 	}
 
-	public function fetch_page_of_members_from_campaign($campaign_id, $page_size, $cursor = null) {
-		
-		// Fetches a given page of members with page size and cursor point. Can be used to iterate through lists of members for a given campaign. Campaign id can be acquired from fetch_campaigns or from a saved campaign id variable.  Requires the current user to be creator of the campaign or requires a creator access token
-		$url = "campaigns/{$campaign_id}/members?page%5Bcount%5D={$page_size}";
-		
-		if ($cursor != null) {
-			
-		  $escaped_cursor = urlencode($cursor);
-		  $url = $url . "&page%5Bcursor%5D={$escaped_cursor}";
-		  
-		}
-		
-		return $this->get_data($url);
-		
+    /**
+     * Fetches details about a member from a campaign. Member id can be acquired from
+     * fetch_page_of_members_from_campaign currently_entitled_tiers is the best way to get
+     * info on which membership tiers the user is entitled to.
+     *
+     * Requires the current user to be creator of the campaign or requires a creator access
+     * token.
+     *
+     * @param string|int $member_id
+     * @return array|object|string
+     * @throws APIException
+     * @throws CurlException
+     * @throws \SodiumException
+     */
+	public function fetch_member_details($member_id)
+    {
+		return $this->get_data('members/' . $member_id, [
+            'include' => implode(',', [
+                'address',
+                'campaign',
+                'user',
+                'currently_entitled_tiers'
+            ])
+        ]);
 	}
 
-	public function get_data($suffix) {
-		
+    /**
+     * Fetches a given page of members with page size and cursor point.
+     * Can be used to iterate through lists of members for a given campaign.
+     * Campaign id can be acquired from fetch_campaigns or from a saved campaign id variable.
+     *
+     * Requires the current user to be creator of the campaign or requires a creator access
+     * token.
+     *
+     * @param string|int $campaign_id
+     * @param string|int $page_size
+     * @param string|int|null $cursor
+     * @return array|object|string
+     * @throws APIException
+     * @throws CurlException
+     * @throws \SodiumException
+     */
+	public function fetch_page_of_members_from_campaign($campaign_id, $page_size, $cursor = null)
+    {
+        $args = [
+            'page' => [
+                'count' => $page_size
+            ]
+        ];
+        if (!empty($cursor)) {
+            $args['page']['cursor'] = $cursor;
+        }
+        return $this->get_data('campaigns/' . $campaign_id . '/members', $args);
+	}
+
+    /**
+     * @param string $suffix
+     * @param array $params
+     * @return string|array|object
+     * @throws APIException
+     * @throws CurlException
+     * @throws \SodiumException
+     */
+	public function get_data(string $suffix, array $params = [])
+    {
 		// Construct request:
 		$api_request = $this->api_endpoint . $suffix;
+		if (!empty($params)) {
+		    $api_request .= '?' . http_build_query($params);
+        }
 		
 		// This identifies a unique request
-		$api_request_hash = md5($api_request);
+        if (extension_loaded('sodium')) {
+            $api_request_hash = bin2hex(sodium_crypto_generichash($api_request));
+        } else {
+            $api_request_hash = md5($api_request);
+        }
 
-		// Check if this request exists in the cache and if so, return it directly - avoids repeated requests to API in the same page run for same request string
-
-		if ( isset( self::$request_cache[$api_request_hash] ) ) {
+		// Check if this request exists in the cache and if so, return it directly -
+        // avoids repeated requests to API in the same page run for same request string
+		if (isset(self::$request_cache[$api_request_hash])) {
 			return self::$request_cache[$api_request_hash];		
 		}
 
-		// Request is new - actually perform the request 
-
+		// Request is new - actually perform the request
 		$ch = $this->__create_ch($api_request);
 		$json_string = curl_exec($ch);
+		if (!is_string($json_string)) {
+            throw new CurlException('No response returned from Patreon server');
+        }
 		$info = curl_getinfo($ch);
 		curl_close($ch);
 
 		// don't try to parse a 500-class error, as it's likely not JSON
-		if ( $info['http_code'] >= 500 ) {
+		if ($info['http_code'] >= 500) {
 		  return self::add_to_request_cache($api_request_hash, $json_string);
 		}
 		
 		// don't try to parse a 400-class error, as it's likely not JSON
-		if ( $info['http_code'] >= 400 ) {
+		if ($info['http_code'] >= 400) {
 		  return self::add_to_request_cache($api_request_hash, $json_string);
 		}
 
 		// Parse the return according to the format set by api_return_format variable
-
-		if( $this->api_return_format == 'array' ) {
-		  $return = json_decode($json_string, true);
-		}
-
-		if( $this->api_return_format == 'object' ) {
-		  $return = json_decode($json_string);
-		}
-
-		if( $this->api_return_format == 'json' ) {
-		  $return = $json_string;
-		}
-
-		// Add this new request to the request cache and return it
-		return self::add_to_request_cache($api_request_hash, $return);
-
+        // Then add this new request to the request cache and return it
+		switch ($this->api_return_format) {
+            case 'array':
+                return self::add_to_request_cache(
+                    $api_request_hash,
+                    json_decode($json_string, true)
+                );
+            case 'object':
+                return self::add_to_request_cache(
+                    $api_request_hash,
+                    json_decode($json_string)
+                );
+            case 'json':
+                return self::add_to_request_cache(
+                    $api_request_hash,
+                    $json_string
+                );
+            default:
+                throw new APIException('Unknown return format:' . $this->api_return_format);
+        }
 	}
 
-	private function __create_ch($api_request) {
-
-		// This function creates a cURL handler for a given URL. In our case, this includes entire API request, with endpoint and parameters
+    /**
+     * @param string $api_request
+     * @return resource
+     * @throws CurlException
+     */
+	private function __create_ch($api_request)
+    {
+		// This function creates a cURL handler for a given URL.
+        // In our case, this includes entire API request, with endpoint and parameters
 
 		$ch = curl_init();
+        if (!is_resource($ch)) {
+            throw new CurlException('Could not initialize cURL handle');
+        }
 		curl_setopt($ch, CURLOPT_URL, $api_request);
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 		
-		if ( $this->api_request_method != 'GET' AND $this->curl_postfields ) {
-			curl_setopt( $ch, CURLOPT_POSTFIELDS, $this->curl_postfields );
+		if ($this->api_request_method !== 'GET' && $this->curl_postfields) {
+			curl_setopt($ch, CURLOPT_POSTFIELDS, $this->curl_postfields);
 		}
-		
+
+		// Strict TLS verification
+        curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
+
 		// Set the cURL request method - works for all of them
 		
 		curl_setopt( $ch, CURLOPT_CUSTOMREQUEST, $this->api_request_method );
@@ -149,24 +300,27 @@ class API {
 
 		curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
 		return $ch;
-
 	}
 
-	public static function add_to_request_cache( $api_request_hash, $result ) {
-		
-		// This function manages the array that is used as the cache for API requests. What it does is to accept a md5 hash of entire query string (GET, with url, endpoint and options and all) and then add it to the request cache array 
-		
-		// If the cache array is larger than 50, snip the first item. This may be increased in future
-		
-		if ( !empty(self::$request_cache) && (count( self::$request_cache ) > 50)  ) {
+    /**
+     * This function manages the array that is used as the cache for API
+     * requests. What it does is to accept a md5 hash of entire query string
+     * (GET, with url, endpoint and options and all) and then add it to the
+     * request cache array.
+     *
+     * @param string $api_request_hash
+     * @param string|array|object $result
+     * @return string|array|object
+     */
+	public static function add_to_request_cache($api_request_hash, $result)
+    {
+		// If the cache array is larger than 50, snip the first item.
+        // This may be increased in future
+		if (!empty(self::$request_cache) && (count( self::$request_cache ) > 50)) {
 			array_shift( self::$request_cache );
 		}
 		
 		// Add the new request and return it
-		
 		return self::$request_cache[$api_request_hash] = $result;
-		
 	}
-
-	
 }

--- a/src/Exceptions/APIException.php
+++ b/src/Exceptions/APIException.php
@@ -1,0 +1,7 @@
+<?php
+namespace Patreon\Exceptions;
+
+class APIException extends \Exception
+{
+
+}

--- a/src/Exceptions/CurlException.php
+++ b/src/Exceptions/CurlException.php
@@ -1,0 +1,7 @@
+<?php
+namespace Patreon\Exceptions;
+
+class CurlException extends \Exception
+{
+
+}

--- a/src/OAuth.php
+++ b/src/OAuth.php
@@ -1,43 +1,92 @@
 <?php
 namespace Patreon;
 
-class OAuth {
-  private $client_id;
-  private $client_secret;
+use ParagonIE\HiddenString\HiddenString;
+use Patreon\Exceptions\CurlException;
 
-  public function __construct($client_id, $client_secret) {
-    $this->client_id = $client_id;
-    $this->client_secret = $client_secret;
-  }
+/**
+ * Class OAuth
+ * @package Patreon
+ */
+class OAuth
+{
+    /** @var HiddenString $client_id */
+    private $client_id;
 
-  public function get_tokens($code, $redirect_uri) {
-    return $this->__update_token(array(
-        "grant_type" => "authorization_code",
-        "code" => $code,
-        "client_id" => $this->client_id,
-        "client_secret" => $this->client_secret,
-        "redirect_uri" => $redirect_uri
-    ));
-  }
+    /** @var HiddenString $client_secret */
+    private $client_secret;
 
-  public function refresh_token($refresh_token, $redirect_uri) {
-    return $this->__update_token(array(
-        "grant_type" => "refresh_token",
-        "refresh_token" => $refresh_token,
-        "client_id" => $this->client_id,
-        "client_secret" => $this->client_secret
-    ));
-  }
+    /**
+     * OAuth constructor.
+     *
+     * @param string|HiddenString $client_id
+     * @param string|HiddenString $client_secret
+     */
+    public function __construct($client_id, $client_secret)
+    {
+        if (!($client_id instanceof HiddenString)) {
+            $client_id = new HiddenString($client_id);
+        }
+        if (!($client_secret instanceof HiddenString)) {
+            $client_secret = new HiddenString($client_secret);
+        }
+        $this->client_id = $client_id;
+        $this->client_secret = $client_secret;
+    }
 
-  private function __update_token($params) {
-    $api_endpoint = "https://api.patreon.com/oauth2/token";
-    $ch = curl_init();
-    curl_setopt($ch, CURLOPT_URL, $api_endpoint);
-    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-    curl_setopt($ch, CURLOPT_POST, 1);
-    curl_setopt($ch, CURLOPT_USERAGENT, "Patreon-PHP, version 1.0.0, platform ".php_uname('s').'-'.php_uname('r'));
-    curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($params));
-    return json_decode(curl_exec($ch), true);
-  }
+    /**
+     * @param string $code
+     * @param string $redirect_uri
+     * @return array
+     */
+    public function get_tokens(string $code, string $redirect_uri)
+    {
+        return $this->__update_token([
+            "grant_type" => "authorization_code",
+            "code" => $code,
+            "client_id" => $this->client_id->getString(),
+            "client_secret" => $this->client_secret->getString(),
+            "redirect_uri" => $redirect_uri
+        ]);
+    }
 
+    /**
+     * @param string $refresh_token
+     * @return array
+     */
+    public function refresh_token(string $refresh_token)
+    {
+        return $this->__update_token([
+            "grant_type" => "refresh_token",
+            "refresh_token" => $refresh_token,
+            "client_id" => $this->client_id->getString(),
+            "client_secret" => $this->client_secret->getString()
+        ]);
+    }
+
+    /**
+     * @param array $params
+     * @return array
+     * @throws CurlException
+     */
+    private function __update_token(array $params): array
+    {
+        $api_endpoint = "https://api.patreon.com/oauth2/token";
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, $api_endpoint);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt($ch, CURLOPT_POST, 1);
+        curl_setopt($ch, CURLOPT_USERAGENT, "Patreon-PHP, version 1.0.0, platform ".php_uname('s').'-'.php_uname('r'));
+        curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($params));
+
+        // Strict TLS verification
+        curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
+        $response = curl_exec($ch);
+        if (!is_string($response)) {
+            throw new CurlException('No response returned from Patreon server');
+        }
+
+        return (array) json_decode($response, true);
+    }
 }

--- a/tests/APITest.php
+++ b/tests/APITest.php
@@ -1,0 +1,25 @@
+<?php
+namespace Patreon\Tests;
+
+use ParagonIE\HiddenString\HiddenString;
+use Patreon\API;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class APITest
+ * @package Patreon\Tests
+ */
+class APITest extends TestCase
+{
+    public function testOAuthConstructor()
+    {
+        $this->assertInstanceOf(
+            API::class,
+            new API('test')
+        );
+        $this->assertInstanceOf(
+            API::class,
+            new API(new HiddenString('test'))
+        );
+    }
+}

--- a/tests/OAuthTest.php
+++ b/tests/OAuthTest.php
@@ -1,0 +1,26 @@
+<?php
+namespace Patreon\Tests;
+
+use ParagonIE\HiddenString\HiddenString;
+use Patreon\OAuth;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class OAuthTest
+ * @package Patreon\Tests
+ */
+class OAuthTest extends TestCase
+{
+    public function testOAuthConstructor()
+    {
+        $this->assertInstanceOf(
+            OAuth::class,
+            new OAuth('a', 'b')
+        );
+
+        $this->assertInstanceOf(
+            OAuth::class,
+            new OAuth(new HiddenString('a'), new HiddenString('b'))
+        );
+    }
+}


### PR DESCRIPTION
* Add unit testing (via phpunit)
* Add static analysis (via Psalm)
* Security: Force server-side HTTP request to use TLS (and check certificates)
  * This explicitly chooses the most secure options available
  * Future effort: Migrate to Guzzle instead of using cURL?
* Throw exceptions if cURL fails
* Performance and Security: Use BLAKE2b instead of MD5 for request caching
  * Prevents accidental collisions, which is a real risk since the
    effective cost of attacking MD5 is 2^18
  * Only if ext/sodium is installed (always should be for PHP 7.2+)
* Security: Internally, use HiddenString objects to encapsulate API tokens and OAuth credentials
  * This helps hide sensitive data from stack traces
  * This keeps users' client secrets and access tokens out of tickets