### PR TITLE
Add access token to cache hash logic. Make cache var and function non static.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ NOTE: This library is made to be compatible with the maximum possible variety of
 [soatok's fork](https://github.com/soatok/patreon-php) with PHP 7.x, PHPunit, Psalm, BLAKE2b instead of MD5
 
 ## Installation
-Get the plugin from [Packagist](https://packagist.org/packages/patreon/patreon)
+
+Currently the repo at packagist is at 0.3.x and API v1 only, whereas the one at Github is at 1.0.0 and API v2 due to compatibility reasons for older installations which were done via composer. Until we sync the packagist version with the Github version, please use this repo by cloning it from Github, or upload it to your environment via file transfer.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ NOTE: This library is made to be compatible with the maximum possible variety of
 
 ## Installation
 
-Currently the repo at packagist is at 0.3.x and API v1 only, whereas the one at Github is at 1.0.0 and API v2 due to compatibility reasons for older installations which were done via composer. Until we sync the packagist version with the Github version, please use this repo by cloning it from Github, or upload it to your environment via file transfer.
+Currently the repo at packagist is at 0.3.x and API v1 only, whereas the one at Github is at 1.0.0 and API v2 due to compatibility reasons for older installations which were done via composer. Until we sync the packagist version with the Github version, please use this repo by cloning it from Github, or downloading and uploading it to your environment via file transfer.
 
 ## Usage
 

--- a/src/API.php
+++ b/src/API.php
@@ -157,7 +157,7 @@ class API {
 		// This function manages the array that is used as the cache for API requests. What it does is to accept a md5 hash of entire query string (GET, with url, endpoint and options and all) and then add it to the request cache array 
 		
 		// If the cache array is larger than 50, snip the first item. This may be increased in future
-
+		
 		if ( !empty(self::$request_cache) && (count( self::$request_cache ) > 50)  ) {
 			array_shift( self::$request_cache );
 		}


### PR DESCRIPTION
**Problem**

API request cache needed to be accommodating to use in backend in cases in which more than one access token pertaining to users was used to process users en masse. Existing request cache was suitable for dealing with one Patreon user's info in one page load.

**Solution**

Added access token to the hash logic for creating hashes for request cache entries. This will allow differentiation of calls for different tokens.

Additionally cache var and function were made non static.

**Verification**

Tested. Can be verified by testing in a test installation.

**Does this need tests**

No.