### PR TITLE
Added clearer descriptions for domains/urls used in the examples and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ Currently the repo at packagist is at 0.3.x and API v1 only, whereas the one at 
 
 ### Step 1. Get your client_id and client_secret
 
-Visit the [Patreon platform documentation page](https://www.patreon.com/platform/documentation)
-while logged in as a Patreon creator to register your client.
+Visit the [Patreon platform documentation page](https://www.patreon.com/platform/documentation) while logged in as a Patreon creator to register your client.
 
 This will provide you with a `client_id` and a `client_secret`.
 
@@ -59,12 +58,11 @@ $client_secret = '';  // Replace with your data
 
 // In this case, say, /patreon_login request uri
 
-$redirect_uri = "http://mydomain.com/patreon_login";
+$redirect_uri = "http://mydomain.com/patreon_login"; // Replace http://mydomain.com/patreon_login with the url at your site which is going to receive users returning from Patreon confirmation
 
 // Generate the oAuth url
 
-$href = 'https://www.patreon.com/oauth2/authorize?response_type=code&client_id=' 
-. $client_id . '&redirect_uri=' . urlencode($redirect_uri);
+$href = 'https://www.patreon.com/oauth2/authorize?response_type=code&client_id=' . $client_id . '&redirect_uri=' . urlencode($redirect_uri);
 
 // You can send an array of vars to Patreon and receive them back as they are. Ie, state vars to set the user state, app state or any other info which should be sent back and forth.
 
@@ -74,7 +72,7 @@ $state = array();
 
 // Lets make it a thank you page
 
-$state['final_page'] = 'http://mydomain.com/thank_you';
+$state['final_page'] = 'http://mydomain.com/thank_you'; // Replace http://mydomain.com/thank_you with the url that has your thank you page
 
 // Add any number of vars you need to this array by $state['YOURKEY'] = VARIABLE
 

--- a/examples/create_webhook_to_notify_campaign_changes.php
+++ b/examples/create_webhook_to_notify_campaign_changes.php
@@ -33,7 +33,7 @@ $api_client->curl_postfields = array (
 				'members:update',
 				'members:delete',
 			),
-			'uri' => 'https://pat-php-dev.codebard.com', // Note that your url must start with https://
+			'uri' => 'https://yourdomain.com/webhook_receiver', // Replace https://yourdomain.com/webhook_receiver with the url at your site/app thats going to receive webhook requests. Note that your url must start with https://
 		),
 		'relationships' => array (
 			'campaign' => array (

--- a/examples/log_in_user_via_patreon.php
+++ b/examples/log_in_user_via_patreon.php
@@ -14,12 +14,11 @@ $client_secret = '';  // Replace with your data
 
 // In this case, say, /patreon_login request uri
 
-$redirect_uri = "http://mydomain.com/patreon_login";
+$redirect_uri = "http://mydomain.com/patreon_login"; // Replace http://mydomain.com/patreon_login with the url at your site which is going to receive users returning from Patreon confirmation 
 
 // Generate the oAuth url
 
-$href = 'https://www.patreon.com/oauth2/authorize?response_type=code&client_id=' 
-. $client_id . '&redirect_uri=' . urlencode($redirect_uri);
+$href = 'https://www.patreon.com/oauth2/authorize?response_type=code&client_id=' . $client_id . '&redirect_uri=' . urlencode($redirect_uri);
 
 // You can send an array of vars to Patreon and receive them back as they are. Ie, state vars to set the user state, app state or any other info which should be sent back and forth. 
 
@@ -29,7 +28,7 @@ $href = 'https://www.patreon.com/oauth2/authorize?response_type=code&client_id='
 
 $state = array();
 
-$state['final_page'] = 'http://mydomain.com/thank_you';
+$state['final_page'] = 'http://mydomain.com/thank_you'; // Replace http://mydomain.com/thank_you with the url that has your thank you page
 
 // Add any number of vars you need to this array by $state['key'] = variable value
 

--- a/examples/unified_flow_oauth_login_register_pledge_redirect.php
+++ b/examples/unified_flow_oauth_login_register_pledge_redirect.php
@@ -36,7 +36,7 @@ $client_secret = '';  // Replace with your data
 
 // In this case, say, /patreon_login request uri. This doesnt need to be your final redirect uri. You can send your final redirect uri in your state vars to Patreon, receive it back, and then send your user to that final redirect uri
 
-$redirect_uri = "http://mydomain.com/patreon_login";
+$redirect_uri = "http://mydomain.com/patreon_login"; // Replace http://mydomain.com/patreon_login with the url at your site which is going to receive users returning from Patreon confirmation
 
 // Min cents is the amount in cents that you locked your content or feature with. Say, if a feature or content requires $5 to access in your site/app, then you send 500 as min cents variable. Patreon will ask the user to pledge $5 or more.
 
@@ -60,9 +60,7 @@ $href = 'https://www.patreon.com/oauth2/become-patron?response_type=code&min_cen
 
 $state = array();
 
-$state['final_redirect'] = 'http://mydomain.com/locked-content';
-
-// Or, http://mydomain.com/premium-feature. Or any url at which a locked feature or content will be unlocked after the user is verified to become a qualifying member 
+$state['final_redirect'] = 'http://mydomain.com/locked-content'; // Replace http://mydomain.com/locked-content with the url of the content to be unlocked at your site, or whever you want the user to be directed to after returning from Patreon login/confirmation
 
 // Add any number of vars you need to this array by $state['key'] = variable value
 
@@ -98,7 +96,6 @@ if ( $_GET['code'] != '' ) {
 	// Here you can decode the state var returned from Patreon, and use the final redirect url to redirect your user to the relevant unlocked content or feature in your site/app.
 	
 }
-
 
 // After linking an existing account or a new account with Patreon by saving and matching the tokens for a given user, you can then read the access token (from the database or whatever resource), and then just check if the user is logged into Patreon by using below code. Code from down below can be placed wherever in your app, it doesnt need to be in the redirect_uri at which the Patreon user ends after oAuth. You just need the $access_token for the current user and thats it.
 


### PR DESCRIPTION
**Problem**

Some creators were using the domains and urls in examples and readme as they are, without changing them.

**Solution**

Explicit comments added next to domains and urls that needed to be replaced

**Verification**

Can be observed in example's code

**Does this need tests**

Tested.